### PR TITLE
Fix the evaluation of upper channel limit

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -72,30 +72,30 @@ channel_change(int idx)
 int
 channel_auto_change(void)
 {
-	int new_chan;
+	int new_idx;
 	int ret = 1;
-	int start_chan;
+	int start_idx;
 
 	if (the_time.tv_sec == last_channelchange.tv_sec &&
 	    (the_time.tv_usec - last_channelchange.tv_usec) < conf.channel_time)
 		return 0; /* too early */
 
 	if (conf.do_change_channel) {
-		start_chan = new_chan = conf.channel_idx;
+		start_idx = new_idx = conf.channel_idx;
 		do {
-			new_chan = new_chan + 1;
-			if (new_chan >= conf.num_channels ||
-			    new_chan >= MAX_CHANNELS ||
+			new_idx = new_idx + 1;
+			if (new_idx >= conf.num_channels ||
+			    new_idx >= MAX_CHANNELS ||
 			    (conf.channel_max &&
-			     channel_get_chan_from_idx(new_chan) > conf.channel_max))
-				new_chan = 0;
+			     channel_get_chan_from_idx(new_idx) > conf.channel_max))
+				new_idx = 0;
 
-			ret = channel_change(new_chan);
+			ret = channel_change(new_idx);
 
 		/* try setting different channels in case we get errors only
 		 * on some channels (e.g. ipw2200 reports channel 14 but cannot
 		 * be set to use it). stop if we tried all channels */
-		} while (ret != 1 && new_chan != start_chan);
+		} while (ret != 1 && new_idx != start_idx);
 	}
 
 	last_channelchange = the_time;

--- a/channel.c
+++ b/channel.c
@@ -86,7 +86,8 @@ channel_auto_change(void)
 			new_chan = new_chan + 1;
 			if (new_chan >= conf.num_channels ||
 			    new_chan >= MAX_CHANNELS ||
-			    (conf.channel_max && new_chan >= conf.channel_max))
+			    (conf.channel_max &&
+			     channel_get_chan_from_idx(new_chan) > conf.channel_max))
 				new_chan = 0;
 
 			ret = channel_change(new_chan);


### PR DESCRIPTION
The value of the configuration option ``channel_upper`` (which is a channel number) was incorrectly compared to a channel index which lead to an incorrect channel range limit.

The first commit fixes the issue by converting the index of the next channel to a channel number before comparison.

The second commit is just a refactoring commit, which renames channel variable to make a clearer distinction between channel numbers and channel indices.