### PR TITLE
Channel selection fixes

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -65,6 +65,7 @@ channel_change(int idx)
 		return 0;
 	}
 	conf.channel_idx = idx;
+	last_channelchange = the_time;
 	return 1;
 }
 
@@ -98,7 +99,6 @@ channel_auto_change(void)
 		} while (ret != 1 && new_idx != start_idx);
 	}
 
-	last_channelchange = the_time;
 	return ret;
 }
 

--- a/channel.c
+++ b/channel.c
@@ -131,6 +131,11 @@ channel_init(void) {
 	/* get available channels */
 	conf.num_channels = wext_get_channels(mon, conf.ifname, channels);
 	conf.channel_idx = get_current_wext_channel_idx(mon);
+	if (conf.channel_num_initial > 0)
+	    channel_change(channel_find_index_from_chan(conf.channel_num_initial));
+	else
+	    conf.channel_num_initial = channel_get_chan_from_idx(conf.channel_idx);
+	conf.channel_initialized = 1;
 }
 
 

--- a/conf_options.c
+++ b/conf_options.c
@@ -69,8 +69,12 @@ static int conf_receive_buffer(const char* value) {
 static int conf_channel_set(const char* value) {
 	int n = atoi(value);
 	conf.do_change_channel = 0;
-	// TODO: this does not work @ init time:
-	channel_change(channel_find_index_from_chan(n));
+	if (conf.channel_initialized)
+	    channel_change(channel_find_index_from_chan(n));
+	else
+	    /* We have not yet initialized the channel module, channel will be
+	     * changed in channel_init(). */
+	    conf.channel_num_initial = n;
 	return 1;
 }
 
@@ -262,7 +266,7 @@ static struct conf_option conf_options[] = {
 	{ 'o', "outfile", 		1, NULL,	conf_outfile },
 	{ 't', "node_timeout", 		1, "60",	conf_node_timeout },
 	{ 'b', "receive_buffer",	1, NULL,	conf_receive_buffer },	// NOT dynamic
-	{  0 , "channel",		1, NULL, 	conf_channel_set },	// dynamic, but NOT init
+	{  0 , "channel",		1, NULL, 	conf_channel_set },
 	{ 's', "channel_scan",		0, NULL,	conf_channel_scan },
 	{  0 , "channel_dwell",		1, "250", 	conf_channel_dwell },
 	{ 'u', "channel_upper",		1, NULL, 	conf_channel_upper },

--- a/conf_options.c
+++ b/conf_options.c
@@ -68,7 +68,6 @@ static int conf_receive_buffer(const char* value) {
 
 static int conf_channel_set(const char* value) {
 	int n = atoi(value);
-	conf.do_change_channel = 0;
 	if (conf.channel_initialized)
 	    channel_change(channel_find_index_from_chan(n));
 	else

--- a/display-channel.c
+++ b/display-channel.c
@@ -79,7 +79,6 @@ channel_input(WINDOW *win, int c)
 		break;
 
 	case 'm': case 'M':
-		conf.do_change_channel = 0;
 		echo();
 		curs_set(1);
 		mvwgetnstr(win, 6, 30, buf, 3);

--- a/main.h
+++ b/main.h
@@ -302,6 +302,7 @@ struct config {
 	int			node_timeout;
 	int			channel_time;
 	int			channel_max;
+	int			channel_num_initial;
 	int			channel_idx;	/* index into channels array */
 	int			display_interval;
 	char			display_view;
@@ -324,7 +325,8 @@ struct config {
 				mac_name_lookup:1,
 	/* this isn't exactly config, but wtf... */
 				do_macfilter:1,
-				display_initialized:1;
+				display_initialized:1,
+				channel_initialized:1;
 	int			arphrd; // the device ARP type
 	unsigned char		my_mac_addr[MAC_LEN];
 	int			paused;


### PR DESCRIPTION
This branch consist of three commits.

The first one implements the initial channel selection feature which has been in a TODO list for some time. The initial channel selection allows one to use ``channel=X`` configuration option to make horst tune the radio to the specified channel on startup. Previously it failed because the channel module was uninitialized at the time configuration file was parsed. Commit 7453527 fixes the initial channel selection problem by postponing the selection until the channel module is initialized.

The second commit just moves the channel change timestamping to the function which actually changes the channel.

The third commit allows one to use manual and automatic channel hopping together. Previously, automatic scanning was disabled when channel was changed manually. This commit changes the behavior so that the automatic scanning is not disabled even if channel is changed manually *during* automatic scanning. Effectively, this makes the behavior more orthogonal and removes the unnecessary behavioral coupling ``channel=X`` and ``channel_scan`` configuration options.