### PR TITLE
Interface control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ OBJS=main.o capture$(if $(filter 1,$(PCAP)),-pcap).o protocol_parser.o \
 	display.o display-main.o display-filter.o display-help.o \
 	display-statistics.o display-essid.o display-history.o \
 	display-spectrum.o display-channel.o control.o \
-	radiotap/radiotap.o conf_options.o
-LIBS=-lncurses -lm
-CFLAGS+=-Wall -Wextra -g -I.
+	radiotap/radiotap.o conf_options.o ifctrl-nl80211.o
+LIBS=-lncurses -lm -lnl-3 -lnl-genl-3
+CFLAGS+=-Wall -Wextra -g -I. $(shell pkg-config --cflags libnl-3.0)
 
 ifeq ($(DEBUG),1)
 CFLAGS+=-DDO_DEBUG

--- a/ifctrl-nl80211.c
+++ b/ifctrl-nl80211.c
@@ -1,0 +1,153 @@
+/* horst - Highly Optimized Radio Scanning Tool
+ *
+ * Copyright (C) 2015 Tuomas Räsänen <tuomasjjrasanen@tjjr.fi>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <net/if.h>
+
+#include <netlink/attr.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/family.h>
+
+#include <linux/nl80211.h>
+
+#include "ifctrl.h"
+
+static int ifctrl_nl_prepare(struct nl_sock **const sockp,
+                             struct nl_msg **const msgp,
+                             const enum nl80211_commands cmd,
+                             const char *const interface)
+{
+	struct nl_msg *msg	   = NULL;
+	struct nl_sock *sock       = NULL;
+	struct nl_cache *cache	   = NULL;
+	struct genl_family *family = NULL;
+	int err		           = -1;
+	unsigned int if_index;
+
+	if_index = if_nametoindex(interface);
+	if (!if_index) {
+		fprintf(stderr, "interface %s does not exist\n", interface);
+		goto out;
+	}
+
+	sock = nl_socket_alloc();
+	if (!sock) {
+		fprintf(stderr, "%s\n", "failed to allocate a netlink socket");
+		goto out;
+	}
+
+	err = genl_connect(sock);
+	if (err) {
+		nl_perror(err, "failed to make a generic netlink connection");
+		goto out;
+	}
+
+	err = genl_ctrl_alloc_cache(sock, &cache);
+	if (err) {
+		nl_perror(err, "failed to allocate a netlink controller cache");
+		goto out;
+	}
+
+	family = genl_ctrl_search_by_name(cache, NL80211_GENL_NAME);
+	if (!family) {
+		fprintf(stderr, "%s\n", "failed to find a generic netlink "
+                        "family object");
+		goto out;
+	}
+
+	msg = nlmsg_alloc();
+	if (!msg) {
+		fprintf(stderr, "%s\n", "failed to allocate a netlink message");
+		goto out;
+	}
+
+	if (!genlmsg_put(msg, 0, 0, genl_family_get_id(family), 0, 0, cmd, 0)) {
+		fprintf(stderr, "%s\n", "failed to add generic netlink headers "
+                        "to a nelink message");
+		goto out;
+	}
+
+	err = nla_put_u32(msg, NL80211_ATTR_IFINDEX, if_index);
+	if (err) {
+		nl_perror(err, "failed to add interface index attribute to a "
+                          "netlink message");
+		goto out;
+	}
+
+	err = 0;
+out:
+	genl_family_put(family);
+	nl_cache_free(cache);
+
+	if (err) {
+		nlmsg_free(msg);
+		nl_socket_free(sock);
+		return -1;
+	}
+
+	*sockp = sock;
+	*msgp = msg;
+
+	return 0;
+}
+
+static int ifctrl_nl_send(struct nl_sock *const sock, struct nl_msg *const msg)
+{
+	int err;
+
+	err = nl_send_sync(sock, msg); /* frees nl_msg */
+	nl_socket_free(sock);
+
+	if (!err)
+		return 0;
+
+	nl_perror(err, "failed to send a netlink message");
+	return -1;
+}
+
+int ifctrl_iwadd_monitor(const char *const interface, 
+                         const char *const monitor_interface)
+{
+	struct nl_sock *sock;
+	struct nl_msg *msg;
+	int err;
+
+	if (ifctrl_nl_prepare(&sock, &msg, NL80211_CMD_NEW_INTERFACE, interface))
+		return -1;
+
+	err = nla_put_string(msg, NL80211_ATTR_IFNAME, monitor_interface);
+	if (err) {
+		nl_perror(err, "failed to add interface name attribute to a "
+                          "netlink message");
+		goto err;
+	}
+
+	err = nla_put_u32(msg, NL80211_ATTR_IFTYPE, NL80211_IFTYPE_MONITOR);
+	if (err) {
+		nl_perror(err, "failed to add interface type attribute to a "
+                          "netlink message");
+		goto err;
+	}
+
+	return ifctrl_nl_send(sock, msg); /* frees sock and msg */
+err:
+	nlmsg_free(msg);
+	nl_socket_free(sock);
+	return -1;
+}

--- a/ifctrl-nl80211.c
+++ b/ifctrl-nl80211.c
@@ -151,3 +151,14 @@ err:
 	nl_socket_free(sock);
 	return -1;
 }
+
+int ifctrl_iwdel(const char *const interface)
+{
+	struct nl_sock *sock;
+	struct nl_msg *msg;
+
+	if (ifctrl_nl_prepare(&sock, &msg, NL80211_CMD_DEL_INTERFACE, interface))
+		return -1;
+
+	return ifctrl_nl_send(sock, msg); /* frees sock and msg */
+}

--- a/ifctrl-nl80211.c
+++ b/ifctrl-nl80211.c
@@ -162,3 +162,24 @@ int ifctrl_iwdel(const char *const interface)
 
 	return ifctrl_nl_send(sock, msg); /* frees sock and msg */
 }
+
+int ifctrl_iwset_monitor(const char *const interface)
+{
+	struct nl_sock *sock;
+	struct nl_msg *msg;
+	int err;
+
+	if (ifctrl_nl_prepare(&sock, &msg, NL80211_CMD_SET_INTERFACE, interface))
+		return -1;
+
+	err = nla_put_u32(msg, NL80211_ATTR_IFTYPE, NL80211_IFTYPE_MONITOR);
+	if (err) {
+		nl_perror(err, "failed to add interface type attribute to a "
+                          "netlink message");
+		nlmsg_free(msg);
+		nl_socket_free(sock);
+		return -1;
+	}
+
+	return ifctrl_nl_send(sock, msg); /* frees msg and sock */
+}

--- a/ifctrl.h
+++ b/ifctrl.h
@@ -30,4 +30,13 @@
  */
 int ifctrl_iwadd_monitor(const char *interface, const char *monitor_interface);
 
+/**
+ * ifctrl_iwdel() - delete 802.11 interface
+ *
+ * @interface: the name of the interface
+ *
+ * Return 0 on success, -1 on error.
+ */
+int ifctrl_iwdel(const char *interface);
+
 #endif

--- a/ifctrl.h
+++ b/ifctrl.h
@@ -1,0 +1,33 @@
+/* horst - Highly Optimized Radio Scanning Tool
+ *
+ * Copyright (C) 2015 Tuomas Räsänen <tuomasjjrasanen@tjjr.fi>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef IFCTRL_H
+#define IFCTRL_H
+
+/**
+ * ifctrl_iwadd_monitor() - add virtual 802.11 monitor interface
+ *
+ * @interface: the name of the interface the monitor interface is attached to
+ * @monitor_interface: the name of the new monitor interface
+ *
+ * Return 0 on success, -1 on error.
+ */
+int ifctrl_iwadd_monitor(const char *interface, const char *monitor_interface);
+
+#endif

--- a/ifctrl.h
+++ b/ifctrl.h
@@ -39,4 +39,13 @@ int ifctrl_iwadd_monitor(const char *interface, const char *monitor_interface);
  */
 int ifctrl_iwdel(const char *interface);
 
+/**
+ * ifctrl_iwset_monitor() - set 802.11 interface to monitor mode
+ *
+ * @interface: the name of the interface
+ *
+ * Return 0 on success, -1 on error.
+ */
+int ifctrl_iwset_monitor(const char *interface);
+
 #endif

--- a/main.c
+++ b/main.c
@@ -624,6 +624,14 @@ static void generate_mon_ifname(char *const buf, const size_t buf_size)
 	}
 }
 
+static void open_monitor(void)
+{
+	mon = open_packet_socket(conf.ifname, conf.recv_buffer_size);
+	if (mon <= 0)
+		err(1, "Couldn't open packet socket");
+	conf.arphrd = device_get_hwinfo(mon, conf.ifname, conf.my_mac_addr);
+}
+
 int
 main(int argc, char** argv)
 {
@@ -668,11 +676,7 @@ main(int argc, char** argv)
 		if (ifctrl_iwset_monitor(conf.ifname))
 			warnx("failed to set interface '%s' to monitor mode",
 			      conf.ifname);
-		mon = open_packet_socket(conf.ifname, conf.recv_buffer_size);
-		if (mon <= 0)
-			err(1, "Couldn't open packet socket");
-
-		conf.arphrd = device_get_hwinfo(mon, conf.ifname, conf.my_mac_addr);
+		open_monitor();
 		if (conf.arphrd != ARPHRD_IEEE80211_PRISM &&
 		    conf.arphrd != ARPHRD_IEEE80211_RADIOTAP) {
 			char mon_ifname[IF_NAMESIZE];
@@ -691,10 +695,7 @@ main(int argc, char** argv)
 			/* Now we have a new monitor interface, proceed
 			 * normally. The interface will be deleted at exit. */
 
-			mon = open_packet_socket(conf.ifname, conf.recv_buffer_size);
-			if (mon <= 0)
-				err(1, "Couldn't open packet socket");
-			conf.arphrd = device_get_hwinfo(mon, conf.ifname, conf.my_mac_addr);
+			open_monitor();
 		}
 
 		channel_init();

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <err.h>
 #include <sys/socket.h>
+#include <net/if.h>
 
 #include "main.h"
 #include "util.h"
@@ -41,6 +42,7 @@
 #include "node.h"
 #include "essid.h"
 #include "conf_options.h"
+#include "ifctrl.h"
 
 
 struct list_head nodes;
@@ -86,6 +88,8 @@ static fd_set write_fds;
 static fd_set excpt_fds;
 
 static volatile sig_atomic_t is_sigint_caught;
+
+static int is_interface_added;
 
 void __attribute__ ((format (printf, 1, 2)))
 printlog(const char *fmt, ...)
@@ -499,6 +503,9 @@ finish_all(void)
 	if (!conf.serveraddr[0] != '\0')
 		close_packet_socket(mon, conf.ifname);
 
+	if (is_interface_added)
+		ifctrl_iwdel(conf.ifname);
+
 	if (DF != NULL) {
 		fclose(DF);
 		DF = NULL;
@@ -599,6 +606,23 @@ const char* mac_name_lookup(const unsigned char* mac, int shorten_mac) {
 	return shorten_mac ? ether_sprintf_short(mac) : ether_sprintf(mac);
 }
 
+static void generate_mon_ifname(char *const buf, const size_t buf_size)
+{
+	unsigned int i;
+
+	for (i=0;; ++i) {
+		int len;
+
+		len = snprintf(buf, buf_size, "horst%d", i);
+		if (len < 0)
+			err(1, "failed to generate a monitor interface name");
+		if ((unsigned int) len >= buf_size)
+			errx(1, "failed to generate a sufficiently short "
+			     "monitor interface name");
+		if (!if_nametoindex(buf))
+			break;
+	}
+}
 
 int
 main(int argc, char** argv)
@@ -641,6 +665,9 @@ main(int argc, char** argv)
 	if (conf.serveraddr[0] != '\0')
 		mon = net_open_client_socket(conf.serveraddr, conf.port);
 	else {
+		if (ifctrl_iwset_monitor(conf.ifname))
+			warnx("failed to set interface '%s' to monitor mode",
+			      conf.ifname);
 		mon = open_packet_socket(conf.ifname, conf.recv_buffer_size);
 		if (mon <= 0)
 			err(1, "Couldn't open packet socket");
@@ -648,9 +675,26 @@ main(int argc, char** argv)
 		conf.arphrd = device_get_hwinfo(mon, conf.ifname, conf.my_mac_addr);
 		if (conf.arphrd != ARPHRD_IEEE80211_PRISM &&
 		    conf.arphrd != ARPHRD_IEEE80211_RADIOTAP) {
-			printf("You need to put your interface into monitor mode!\n");
-			printf("(e.g. 'iw %s interface add mon0 type monitor' and 'horst -i mon0')\n", conf.ifname);
-			exit(1);
+			char mon_ifname[IF_NAMESIZE];
+
+			warnx("interface '%s' is not in monitor mode, "
+			      "adding a virtual monitor interface",
+			      conf.ifname);
+
+			close_packet_socket(mon, conf.ifname);
+			generate_mon_ifname(mon_ifname, IF_NAMESIZE);
+			if (ifctrl_iwadd_monitor(conf.ifname, mon_ifname))
+				err(1, "failed to add a virtual monitor "
+				    "interface");
+			strncpy(conf.ifname, mon_ifname, MAX_CONF_VALUE_LEN);
+			is_interface_added = 1;
+			/* Now we have a new monitor interface, proceed
+			 * normally. The interface will be deleted at exit. */
+
+			mon = open_packet_socket(conf.ifname, conf.recv_buffer_size);
+			if (mon <= 0)
+				err(1, "Couldn't open packet socket");
+			conf.arphrd = device_get_hwinfo(mon, conf.ifname, conf.my_mac_addr);
 		}
 
 		channel_init();


### PR DESCRIPTION
Hi

This pull request consists of 5 commits, aimed to provide support for setting
the interface in monitor mode automatically at start-up and thus getting rid of
manual interface management.

To enable a monitor interface automatically at start-up, two different methods
are used, in the given order:
    
  1. Try to set the current interface to monitor mode.
    
  2. If modifying the current interface fails (e.g. it is in use and busy), then
     horst adds a virtual monitor interface to the current interface and uses it
     instead.

All wireless interface modifications are carried out using Netlink APIs, so the
implementation is Linux-only (`ifctrl-nl80211.c`). However, internally all
functionality is hidden behind platform-independent `ifctrl.h`, so adding
support for new platforms does not need to touch any other code than the
platform-specific module implementing the internal API.
