### PR TITLE
Add new configuration option: channel_scan_rounds=X

### DIFF
--- a/conf_options.c
+++ b/conf_options.c
@@ -88,6 +88,18 @@ static int conf_channel_scan(const char* value) {
 	return 1;
 }
 
+/*
+ * This configuration option (channel_scan_rounds=X) defines the number of
+ * rounds horst scans the channel spectrum when the automatic channel scanning
+ * is enabled (channel_scan=1). A scan round is considered to be complete when
+ * the current channel is changed back to the initial channel. When horst goes
+ * out of scan rounds, it quits.
+ */
+static int conf_channel_scan_rounds(const char* value) {
+	conf.channel_scan_rounds = atoi(value);
+	return 1;
+}
+
 static int conf_channel_dwell(const char* value) {
 	conf.channel_time = atoi(value) * 1000;
 	return 1;
@@ -271,6 +283,7 @@ static struct conf_option conf_options[] = {
 	{ 'b', "receive_buffer",	1, NULL,	conf_receive_buffer },	// NOT dynamic
 	{ 'C', "channel",		1, NULL, 	conf_channel_set },
 	{ 's', "channel_scan",		0, NULL,	conf_channel_scan },
+	{  0 , "channel_scan_rounds",	1, "-1",	conf_channel_scan_rounds },
 	{  0 , "channel_dwell",		1, "250", 	conf_channel_dwell },
 	{ 'u', "channel_upper",		1, NULL, 	conf_channel_upper },
 	{ 'N', "server",		0, NULL,	conf_server },		// NOT dynamic

--- a/horst.conf
+++ b/horst.conf
@@ -12,6 +12,7 @@
 # receive_buffer = bytes
 # channel = channel number
 # channel_scan
+# channel_scan_rounds = the number of times the channel spectrum is scanned (-1)
 # channel_dwell = milliseconds (250)
 # channel_upper = channel number
 # server

--- a/main.c
+++ b/main.c
@@ -732,7 +732,7 @@ main(int argc, char** argv)
 	    sigprocmask(SIG_BLOCK, &workmask, &waitmask) == -1)
 		err(1, "failed to block signals: %m");
 
-	for ( /* ever */ ;;)
+	while (!conf.do_change_channel || conf.channel_scan_rounds != 0)
 	{
 		receive_any(&waitmask);
 
@@ -748,10 +748,13 @@ main(int argc, char** argv)
 				update_spectrum_durations();
 				if (!conf.quiet && !conf.debug)
 					update_display(NULL);
+
+				if (channel_get_chan_from_idx(conf.channel_idx) == conf.channel_num_initial
+				    && conf.channel_scan_rounds > 0)
+					--conf.channel_scan_rounds;
 			}
 		}
 	}
-	/* will never */
 	return 0;
 }
 

--- a/main.h
+++ b/main.h
@@ -305,6 +305,7 @@ struct config {
 	int			channel_max;
 	int			channel_num_initial;
 	int			channel_idx;	/* index into channels array */
+	int			channel_scan_rounds;
 	int			display_interval;
 	char			display_view;
 	char			dumpfile[MAX_CONF_VALUE_STRLEN + 1];


### PR DESCRIPTION
This configuration option determines the number of times horst scans the channel
spectrum when channel_scan=1. By default, channel_scan_rounds=-1 which means
that horst scans forever, so this commit preserves the old default behavior.

The purpose of this configuration option is to make it possible to run horst for
a predetermined period of time. If used in conjunction with channel=,
channel_upper= and channel_dwell=, horst can be configured to scan an arbitrary
range of channels for an arbitrary but predetermined period of time.

This allows horst to be used as a generic, well-controlled and easy-to-use
"backend" process providing scanning results for higher-level applications.