### PR TITLE
improve color usage

### DIFF
--- a/display.c
+++ b/display.c
@@ -476,6 +476,7 @@ init_display(void)
 {
 	initscr();
 	start_color();	/* Start the color functionality */
+	use_default_colors();
 	keypad(stdscr, TRUE);
 	nonl();		/* tell curses not to do NL->CR/NL on output */
 	cbreak();	/* take input chars one at a time, no wait for \n */


### PR DESCRIPTION
When using some transparency and custom terminal color, the default behaviour is not working.
On this screeshot, you can see the 'master' (left) version with the 'use_default_colors' (right) version.
https://clea.maxux.net/screenshots/26-08-15-030527.png

You will see that some text are missing because it's rendered as black on black.
I could improve my pull request to add an option to use or not default color. And fix the black text background issue with the 'use_default_colors' if you want too.