### PR TITLE
Error handling and output fixes

### DIFF
--- a/capture.c
+++ b/capture.c
@@ -135,7 +135,7 @@ open_packet_socket(char* devname, int recv_buffer_size)
 
 	mon_fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 	if (mon_fd < 0) {
-		printf("Could not create packet socket! Please run horst as root!\n");
+		printlog("Could not create packet socket! Please run horst as root!");
 		exit(1);
 	}
 

--- a/channel.c
+++ b/channel.c
@@ -47,8 +47,9 @@ channel_get_current_chan() {
 	return -1;
 }
 
-void
+int
 channel_init(void) {
+	return 1;
 }
 
 #else
@@ -152,16 +153,19 @@ get_current_wext_channel_idx(int mon)
 }
 
 
-void
+int
 channel_init(void) {
 	/* get available channels */
 	conf.num_channels = wext_get_channels(mon, conf.ifname, channels);
 	conf.channel_idx = get_current_wext_channel_idx(mon);
-	if (conf.channel_num_initial > 0)
-	    channel_change(channel_find_index_from_chan(conf.channel_num_initial));
-	else
+	if (conf.channel_num_initial > 0) {
+	    if (!channel_change(channel_find_index_from_chan(conf.channel_num_initial)))
+	        return 0;
+	} else {
 	    conf.channel_num_initial = channel_get_chan_from_idx(conf.channel_idx);
+	}
 	conf.channel_initialized = 1;
+	return 1;
 }
 
 

--- a/channel.h
+++ b/channel.h
@@ -49,7 +49,7 @@ channel_get_chan_from_idx(int idx);
 int
 channel_get_current_chan();
 
-void
+int
 channel_init(void);
 
 struct chan_freq*

--- a/control.c
+++ b/control.c
@@ -56,7 +56,7 @@ control_send_command(const char* cmd)
 	}
 
 	while (access(conf.control_pipe, F_OK) < 0) {
-		printf("Waiting for control pipe '%s'...\n", conf.control_pipe);
+		printlog("Waiting for control pipe '%s'...", conf.control_pipe);
 		sleep(1);
 	}
 
@@ -74,7 +74,7 @@ control_send_command(const char* cmd)
 		*pos = '\n';
 	}
 
-	printf("Sending command: %s\n", new);
+	printlog("Sending command: %s", new);
 
 	write(ctlpipe, new, len+1);
 	close(ctlpipe);

--- a/main.c
+++ b/main.c
@@ -705,7 +705,8 @@ main(int argc, char** argv)
 			err(1, "interface '%s' is not in monitor mode",
 			    conf.ifname);
 
-		channel_init();
+		if (!channel_init() && conf.quiet)
+			err(1, "failed to change the initial channel number");
 		init_spectrum();
 	}
 

--- a/main.c
+++ b/main.c
@@ -102,7 +102,7 @@ printlog(const char *fmt, ...)
 	va_end(ap);
 
 	if (conf.quiet || conf.debug || !conf.display_initialized)
-		printf("%s\n", &buf[1]);
+		fprintf(stderr, "%s\n", &buf[1]);
 	else {
 		/* fix up string for display log */
 		buf[0] = '\n';

--- a/main.c
+++ b/main.c
@@ -592,8 +592,8 @@ mac_name_file_read(const char* filename) {
 	node_names.count = idx;
 
 	for (n = 0; n < node_names.count; n++) {
-		printf("MAC %s = %s\n", ether_sprintf(node_names.entry[n].mac),
-		       node_names.entry[n].name );
+		printlog("MAC %s = %s", ether_sprintf(node_names.entry[n].mac),
+			 node_names.entry[n].name );
 	}
 }
 


### PR DESCRIPTION
Hi

Here's fixes to few issues which I encountered when I ran horst in
quiet mode and output scan results to stdout:

1. The output (scan results) was mixed with log messages.

2. If horst was configured to set the initial channel (channel=X), but
   the channel selection failed (e.g. used virtual monitor interface),
   horst continued initialization instead of exiting with an error.

   In my opinion, horst should just exit with an error if it fails to
   run meet the configuration requirements.
