### PR TITLE
Add numeric timezones to output file timestamps

### DIFF
--- a/horst.1
+++ b/horst.1
@@ -569,7 +569,7 @@ following fields in the following order, one packet each line.
 
 .TP
 timestamp
-Local time, including microseconds (e.g. 2015-05-16 15:05:44.338806)
+Local time, including microseconds (e.g. 2015-05-16 15:05:44.338806 +0300)
 .TP
 packet_type
 802.11 MAC packet type name as defined in the section "NAMES AND ABBREVIATIONS".

--- a/main.c
+++ b/main.c
@@ -225,9 +225,10 @@ write_to_file(struct packet_info* p)
 	int i;
 	struct tm* ltm = localtime(&the_time.tv_sec);
 
-	//timestamp, e.g. 2015-05-16 15:05:44.338806
+	//timestamp, e.g. 2015-05-16 15:05:44.338806 +0300
 	i = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ltm);
-	snprintf(buf+i, sizeof(buf)-i, ".%06ld", the_time.tv_usec);
+	i += snprintf(buf + i, sizeof(buf) - i, ".%06ld", the_time.tv_usec);
+	i += strftime(buf + i, sizeof(buf) - i, " %z", ltm);
 	fprintf(DF, "%s, ", buf);
 
 	fprintf(DF, "%s, %s, ",


### PR DESCRIPTION
Timezone information makes output files transferable, in both host and
time space.