### PR TITLE
Fix #47, Implement `clock_gettime` wrapper for Mac OS X / Mach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ ifeq ($(OSX),1)
     WEXT=0
     LIBNL=0
     LIBS+=-framework CoreWLAN -framework CoreData -framework Foundation
+    OBJS+=mach_clock_gettime.o
 endif
 
 ifeq ($(DEBUG),1)

--- a/mach_clock_gettime.c
+++ b/mach_clock_gettime.c
@@ -1,0 +1,68 @@
+/*
+ * mach_clock_gettime --- an emulation of POSIX's `clock_gettime` for
+ * Mach / Mac OS X.
+ *
+ * This library emulates a function from the POSIX Realtime Extensions
+ * for getting monotonically increasing clock readings (`clock_gettime`
+ * with a `clock_id` of `CLOCK_MONOTONIC`) using Mac OS X's `clock_get_time`
+ * call on the monotonically increasing `SYSTEM_CLOCK` clock service.
+ *
+ * It is designed as a drop-in replacement for that specific purpose:
+ * Do a conditional include of this library on systems that define
+ * __MACH__, then use `clock_gettime(CLOCK_MONOTONIC, &...)` as if on
+ * a system that implements the POSIX Realtime Extensions.
+ *
+ * Other clock sources, alarms, etc. are currently not supported.
+ *
+ * This library is based on material by
+ * - The Open Group, see
+ *     http://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_gettime.html
+ * - the Linux kernel headers, see time.h, posix_types.h and types.h
+ * - The XNU man pages, see host_get_clock_service, clock_get_time and
+     tvalspec under https://opensource.apple.com/source/xnu/xnu-3248.60.10/osfmk/man/
+ * - https://stackoverflow.com/questions/11680461/monotonic-clock-on-osx
+ *
+ * Other similar (and probably more complete) approaches exist and inspired
+ * this implementation, see for instance
+ * - https://gist.github.com/jbenet/1087739
+ * - https://gist.github.com/alfwatt/3588c5aa1f7a1ef7a3bb
+ * - https://github.com/ChisholmKyle/PosixMachTiming
+ *
+ * Licensing note: Given its vanishing amount of originality, this library
+ * is placed under a CC0 license, i.e. I release it into the public domain.
+ * See also https://creativecommons.org/publicdomain/zero/1.0/legalcode
+ *
+ * Please send bug reports to albert.rafetseder@univie.ac.at
+ */
+
+#include <sys/types.h>
+#include <mach/clock.h>
+#include <mach/mach.h>
+#include <err.h>
+
+#include "mach_clock_gettime.h"
+
+int clock_gettime(clockid_t clock_id, struct timespec *tp)
+{
+	/* The XNU docs prescribe `clock_t` and `tvalspec_t` for the
+	 * first two variables; we however use what the header file
+	 * in /usr/include/mach/clock.h tells us to (or else the
+	 * preprocessor complains). */
+	clock_serv_t clock_name;
+	mach_timespec_t current_clock_value;
+        kern_return_t retval;
+
+	/* Bail out on clock_id's that we don't emulate */
+	if (clock_id != CLOCK_MONOTONIC)
+		err(1, "Unsupported clock_id for mach_clock_gettime emulation");
+
+	/* XXX This could use some more error checking... */
+	host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &clock_name);
+	retval = clock_get_time(clock_name, &current_clock_value);
+	mach_port_deallocate(mach_task_self(), clock_name);
+	tp->tv_sec = current_clock_value.tv_sec;
+	tp->tv_nsec = current_clock_value.tv_nsec;
+
+	return retval;
+}
+

--- a/mach_clock_gettime.h
+++ b/mach_clock_gettime.h
@@ -1,0 +1,20 @@
+/*
+ * mach_clock_gettime --- an emulation of POSIX's `clock_gettime` for
+ * Mach / Mac OS X.
+ *
+ * See mach_clock_gettime.c for details.
+ */
+
+#ifndef _MACH_CLOCK_GETTIME_H_
+#define _MACH_CLOCK_GETTIME_H_
+
+#include <time.h>
+
+#define CLOCK_MONOTONIC 1	/* Per Linux's time.h */
+typedef int clockid_t;		/* Per Linux's types.h, posix_types.h */
+
+/* Per the POSIX Realtime Extensions */
+int clock_gettime(clockid_t clock_id, struct timespec *tp);
+
+#endif
+

--- a/main.c
+++ b/main.c
@@ -44,6 +44,10 @@
 #include "conf_options.h"
 #include "ifctrl.h"
 
+#ifdef __MACH__
+#include "mach_clock_gettime.h"
+#endif
+
 struct list_head nodes;
 struct essid_meta_info essids;
 struct history hist;


### PR DESCRIPTION
This fixes a compile problem on Mac OS X that was introduced in c71563a985ebae941219d8ff7920ba1bc027f396 when the `gettimeofday` function was replaced with `clock_gettime`, the latter of which is not available on OS X.

In particular, this commit
* Adds a small wrapper library, `mach_clock_gettime`, that transparently handles calls to `clock_gettime` by appropriately redirecting them to OS X's `clock_get_time` function,
* Adds a conditional include to `main.c` so that systems that define `__MACH__` use the wrapper lib,
* Adds the wrapper lib to the list of object files in `Makefile` that will be built if the user sets the `OSX` build option on the command line.