### PR TITLE
Added option for setting clock id

### DIFF
--- a/conf_options.c
+++ b/conf_options.c
@@ -21,7 +21,6 @@
 #include <string.h>
 #include <getopt.h>
 #include <err.h>
-#include <time.h>
 
 #include <uwifi/util.h>
 #include <uwifi/wlan_util.h>

--- a/conf_options.c
+++ b/conf_options.c
@@ -301,19 +301,19 @@ static bool conf_mac_names(const char* value) {
 	return true;
 }
 
-static bool conf_clock_id(const char* value) {
+static bool conf_display_clock(const char* value) {
 	const char* clock_names[] = { "CLOCK_REALTIME", "CLOCK_MONOTONIC" };
 	const int clock_ids[] = { CLOCK_REALTIME, CLOCK_MONOTONIC };
 	const int num_clocks = sizeof(clock_ids) / sizeof(int);
 
 	for(int i = 0; i < num_clocks; i++) {
 		if (strcmp(value, clock_names[i]) == 0) {
-			conf.clock_id = clock_ids[i];
+			conf.display_clock = clock_ids[i];
 			return true;
 		}
 	}
 
-	printlog(LOG_ERR, "Not supported clock: %s", value);
+	printlog(LOG_ERR, "Not supported display clock: %s", value);
 	return false;
 }
 
@@ -344,7 +344,7 @@ static struct conf_option conf_options[] = {
 	{ 'm', "filter_mode",		1, "ALL",	conf_filter_mode },
 	{ 'f', "filter_packet",		1, "ALL",	conf_filter_pkt },
 	{ 'M', "mac_names",		2, NULL,	conf_mac_names },
-	{ 'T', "clock_id",		1, "CLOCK_MONOTONIC", 	conf_clock_id }
+	{ 'T', "display_clock",		1, "CLOCK_REALTIME",	conf_display_clock }
 };
 
 /*
@@ -496,7 +496,7 @@ static void print_usage(const char* name)
 		"  -V view\tDisplay view: history|essid|statistics|spectrum\n"
 		"  -b <bytes>\tReceive buffer size in bytes (not set)\n"
 		"  -M[filename]\tMAC address to host name mapping (/tmp/dhcp.leases)\n"
-		"  -T <clock_id>\tClock id to use for output (CLOCK_MONOTONIC)\n"
+		"  -T <clock_id>\tClock id to use for output (CLOCK_REALTIME)\n"
 
 		"\nFeature Options:\n"
 		"  -s\t\t(Poor mans) Spectrum analyzer mode\n"

--- a/conf_options.c
+++ b/conf_options.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <err.h>
+#include <time.h>
 
 #include <uwifi/util.h>
 #include <uwifi/wlan_util.h>
@@ -300,6 +301,22 @@ static bool conf_mac_names(const char* value) {
 	return true;
 }
 
+static bool conf_clock_id(const char* value) {
+	const char* clock_names[] = { "CLOCK_REALTIME", "CLOCK_MONOTONIC" };
+	const int clock_ids[] = { CLOCK_REALTIME, CLOCK_MONOTONIC };
+	const int num_clocks = sizeof(clock_ids) / sizeof(int);
+
+	for(int i = 0; i < num_clocks; i++) {
+		if (strcmp(value, clock_names[i]) == 0) {
+			conf.clock_id = clock_ids[i];
+			return true;
+		}
+	}
+
+	printlog(LOG_ERR, "Not supported clock: %s", value);
+	return false;
+}
+
 static struct conf_option conf_options[] = {
 	/* C , NAME        VALUE REQUIRED, DEFAULT	CALLBACK */
 	{ 'q', "quiet",			0, NULL,	conf_quiet },		// NOT dynamic
@@ -327,6 +344,7 @@ static struct conf_option conf_options[] = {
 	{ 'm', "filter_mode",		1, "ALL",	conf_filter_mode },
 	{ 'f', "filter_packet",		1, "ALL",	conf_filter_pkt },
 	{ 'M', "mac_names",		2, NULL,	conf_mac_names },
+	{ 'T', "clock_id",		1, "CLOCK_MONOTONIC", 	conf_clock_id }
 };
 
 /*
@@ -478,6 +496,7 @@ static void print_usage(const char* name)
 		"  -V view\tDisplay view: history|essid|statistics|spectrum\n"
 		"  -b <bytes>\tReceive buffer size in bytes (not set)\n"
 		"  -M[filename]\tMAC address to host name mapping (/tmp/dhcp.leases)\n"
+		"  -T <clock_id>\tClock id to use for output (CLOCK_MONOTONIC)\n"
 
 		"\nFeature Options:\n"
 		"  -s\t\t(Poor mans) Spectrum analyzer mode\n"

--- a/conf_options.c
+++ b/conf_options.c
@@ -301,22 +301,6 @@ static bool conf_mac_names(const char* value) {
 	return true;
 }
 
-static bool conf_display_clock(const char* value) {
-	const char* clock_names[] = { "CLOCK_REALTIME", "CLOCK_MONOTONIC" };
-	const int clock_ids[] = { CLOCK_REALTIME, CLOCK_MONOTONIC };
-	const int num_clocks = sizeof(clock_ids) / sizeof(int);
-
-	for(int i = 0; i < num_clocks; i++) {
-		if (strcmp(value, clock_names[i]) == 0) {
-			conf.display_clock = clock_ids[i];
-			return true;
-		}
-	}
-
-	printlog(LOG_ERR, "Not supported display clock: %s", value);
-	return false;
-}
-
 static struct conf_option conf_options[] = {
 	/* C , NAME        VALUE REQUIRED, DEFAULT	CALLBACK */
 	{ 'q', "quiet",			0, NULL,	conf_quiet },		// NOT dynamic
@@ -343,8 +327,7 @@ static struct conf_option conf_options[] = {
 	{ 'B', "filter_bssid", 		1, NULL,	conf_filter_bssid },
 	{ 'm', "filter_mode",		1, "ALL",	conf_filter_mode },
 	{ 'f', "filter_packet",		1, "ALL",	conf_filter_pkt },
-	{ 'M', "mac_names",		2, NULL,	conf_mac_names },
-	{ 'T', "display_clock",		1, "CLOCK_REALTIME",	conf_display_clock }
+	{ 'M', "mac_names",		2, NULL,	conf_mac_names }
 };
 
 /*
@@ -496,7 +479,6 @@ static void print_usage(const char* name)
 		"  -V view\tDisplay view: history|essid|statistics|spectrum\n"
 		"  -b <bytes>\tReceive buffer size in bytes (not set)\n"
 		"  -M[filename]\tMAC address to host name mapping (/tmp/dhcp.leases)\n"
-		"  -T <clock_id>\tClock id to use for output (CLOCK_REALTIME)\n"
 
 		"\nFeature Options:\n"
 		"  -s\t\t(Poor mans) Spectrum analyzer mode\n"

--- a/conf_options.c
+++ b/conf_options.c
@@ -327,7 +327,7 @@ static struct conf_option conf_options[] = {
 	{ 'B', "filter_bssid", 		1, NULL,	conf_filter_bssid },
 	{ 'm', "filter_mode",		1, "ALL",	conf_filter_mode },
 	{ 'f', "filter_packet",		1, "ALL",	conf_filter_pkt },
-	{ 'M', "mac_names",		2, NULL,	conf_mac_names }
+	{ 'M', "mac_names",		2, NULL,	conf_mac_names },
 };
 
 /*

--- a/display-essid.c
+++ b/display-essid.c
@@ -64,7 +64,7 @@ void update_essid_win(WINDOW *win)
 			if (line > LINES-3)
 				break;
 
-			if (n->last_seen > (the_time.tv_sec - conf.node_timeout / 2))
+			if (n->last_seen > (time_mono.tv_sec - conf.node_timeout / 2))
 				wattron(win, A_BOLD);
 			else
 				wattroff(win, A_BOLD);

--- a/display-main.c
+++ b/display-main.c
@@ -237,7 +237,7 @@ static void print_node_list_line(int line, struct uwifi_node* n)
 
 	if (n->pkt_types & PKT_TYPE_OLSR)
 		wattron(list_win, GREEN);
-	if (n->last_seen > (the_time.tv_sec - conf.node_timeout / 2))
+	if (n->last_seen > (time_mono.tv_sec - conf.node_timeout / 2))
 		wattron(list_win, A_BOLD);
 	else
 		wattron(list_win, A_NORMAL);

--- a/display.c
+++ b/display.c
@@ -54,14 +54,14 @@ void get_per_second(unsigned long bytes, unsigned long duration,
 	float timediff;
 
 	/* reacalculate only every second or more */
-	timediff = (the_time.tv_sec + the_time.tv_nsec/1000000000.0) -
+	timediff = (time_mono.tv_sec + time_mono.tv_nsec/1000000000.0) -
 		   (last.tv_sec + last.tv_nsec/1000000000.0);
 	if (timediff >= 1.0) {
 		last_dps = (1.0*(duration - last_dur)) / timediff;
 		last_bps = (1.0*(bytes - last_bytes)) / timediff;
 		last_pps = (1.0*(packets - last_pkts)) / timediff;
 		last_rps = (1.0*(retries - last_retr)) / timediff;
-		last = the_time;
+		last = time_mono;
 		last_dur = duration;
 		last_bytes = bytes;
 		last_pkts = packets;
@@ -239,7 +239,7 @@ static void update_menu(void)
 	wattroff(stdscr, BLACKONWHITE);
 
 	update_mini_status();
-	update_clock(&the_time.tv_sec);
+	update_clock(&time_real.tv_sec);
 }
 
 /******************* WINDOW MANAGEMENT / UPDATE *******************/
@@ -306,8 +306,8 @@ static void show_conf_window(int key)
 void update_display_clock(void)
 {
 	/* helper to update just the clock every second */
-	if (the_time.tv_sec > last_time.tv_sec) {
-		update_clock(&the_time.tv_sec);
+	if (time_mono.tv_sec > last_time.tv_sec) {
+		update_clock(&time_real.tv_sec);
 		doupdate();
 	}
 }
@@ -330,8 +330,8 @@ void update_display(struct uwifi_packet* pkt)
 	 * if pkt is NULL we want to force an update
 	 */
 	if (pkt != NULL &&
-	    the_time.tv_sec == last_time.tv_sec &&
-	    (the_time.tv_nsec - last_time.tv_nsec) / 1000 < conf.display_interval ) {
+	    time_mono.tv_sec == last_time.tv_sec &&
+	    (time_mono.tv_nsec - last_time.tv_nsec) / 1000 < conf.display_interval ) {
 		/* just add the line to dump win so we don't loose it */
 		update_dump_win(pkt);
 		return;
@@ -345,10 +345,10 @@ void update_display(struct uwifi_packet* pkt)
 	update_menu();
 
 	/* update clock every second */
-	if (the_time.tv_sec > last_time.tv_sec)
-		update_clock(&the_time.tv_sec);
+	if (time_mono.tv_sec > last_time.tv_sec)
+		update_clock(&time_real.tv_sec);
 
-	last_time = the_time;
+	last_time = time_mono;
 
 	if (show_win != NULL)
 		update_show_win();

--- a/main.c
+++ b/main.c
@@ -587,8 +587,8 @@ int main(int argc, char** argv)
 
 	atexit(exit_handler);
 
-	clock_gettime(CLOCK_MONOTONIC, &stats.stats_time);
-	clock_gettime(CLOCK_MONOTONIC, &the_time);
+	clock_gettime(conf.clock_id, &stats.stats_time);
+	clock_gettime(conf.clock_id, &the_time);
 
 	conf.intf.channel_idx = -1;
 
@@ -657,7 +657,7 @@ int main(int argc, char** argv)
 		if (is_sigint_caught)
 			exit(1);
 
-		clock_gettime(CLOCK_MONOTONIC, &the_time);
+		clock_gettime(conf.clock_id, &the_time);
 		uwifi_nodes_timeout(&conf.intf.wlan_nodes, conf.node_timeout,
 				    &conf.intf.last_nodetimeout);
 
@@ -700,7 +700,7 @@ void main_reset(void)
 	memset(&stats, 0, sizeof(stats));
 	memset(&spectrum, 0, sizeof(spectrum));
 	init_spectrum();
-	clock_gettime(CLOCK_MONOTONIC, &stats.stats_time);
+	clock_gettime(conf.clock_id, &stats.stats_time);
 }
 
 void dumpfile_open(const char* name)

--- a/main.c
+++ b/main.c
@@ -55,8 +55,8 @@ struct node_names_info node_names;
 
 struct config conf;
 
-struct timespec the_time;
-struct timespec display_time;
+struct timespec time_mono;
+struct timespec time_real;
 
 static FILE* DF = NULL;
 
@@ -211,11 +211,11 @@ static void write_to_file(struct uwifi_packet* p)
 {
 	char buf[40];
 	int i;
-	struct tm* ltm = localtime(&display_time.tv_sec);
+	struct tm* ltm = localtime(&time_real.tv_sec);
 
 	//timestamp, e.g. 2015-05-16 15:05:44.338806 +0300
 	i = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ltm);
-	i += snprintf(buf + i, sizeof(buf) - i, ".%06ld", (long)(display_time.tv_nsec / 1000));
+	i += snprintf(buf + i, sizeof(buf) - i, ".%06ld", (long)(time_real.tv_nsec / 1000));
 	i += strftime(buf + i, sizeof(buf) - i, " %z", ltm);
 	fprintf(DF, "%s, ", buf);
 
@@ -589,8 +589,8 @@ int main(int argc, char** argv)
 	atexit(exit_handler);
 
 	clock_gettime(CLOCK_MONOTONIC, &stats.stats_time);
-	clock_gettime(CLOCK_MONOTONIC, &the_time);
-	clock_gettime(conf.display_clock, &display_time);
+	clock_gettime(CLOCK_MONOTONIC, &time_mono);
+	clock_gettime(CLOCK_REALTIME, &time_real);
 
 	conf.intf.channel_idx = -1;
 
@@ -659,8 +659,8 @@ int main(int argc, char** argv)
 		if (is_sigint_caught)
 			exit(1);
 
-		clock_gettime(CLOCK_MONOTONIC, &the_time);
-		clock_gettime(conf.display_clock, &display_time);
+		clock_gettime(CLOCK_MONOTONIC, &time_mono);
+		clock_gettime(CLOCK_REALTIME, &time_real);
 		uwifi_nodes_timeout(&conf.intf.wlan_nodes, conf.node_timeout,
 				    &conf.intf.last_nodetimeout);
 
@@ -704,7 +704,7 @@ void main_reset(void)
 	memset(&spectrum, 0, sizeof(spectrum));
 	init_spectrum();
 	clock_gettime(CLOCK_MONOTONIC, &stats.stats_time);
-	clock_gettime(conf.display_clock, &display_time);
+	clock_gettime(CLOCK_REALTIME, &time_real);
 }
 
 void dumpfile_open(const char* name)

--- a/main.h
+++ b/main.h
@@ -96,7 +96,7 @@ struct config {
 				monitor_added:1;
 	int			paused;
 	unsigned int		node_timeout;
-	clockid_t		clock_id;
+	clockid_t		display_clock;
 };
 
 extern struct config conf;
@@ -169,6 +169,7 @@ struct node_names_info {
 extern struct node_names_info node_names;
 
 extern struct timespec the_time;
+extern struct timespec display_time;
 
 extern struct list_head nodes;
 

--- a/main.h
+++ b/main.h
@@ -96,6 +96,7 @@ struct config {
 				monitor_added:1;
 	int			paused;
 	unsigned int		node_timeout;
+	clockid_t		clock_id;
 };
 
 extern struct config conf;

--- a/main.h
+++ b/main.h
@@ -96,7 +96,6 @@ struct config {
 				monitor_added:1;
 	int			paused;
 	unsigned int		node_timeout;
-	clockid_t		display_clock;
 };
 
 extern struct config conf;
@@ -168,8 +167,8 @@ struct node_names_info {
 
 extern struct node_names_info node_names;
 
-extern struct timespec the_time;
-extern struct timespec display_time;
+extern struct timespec time_mono;
+extern struct timespec time_real;
 
 extern struct list_head nodes;
 


### PR DESCRIPTION
Hi,

I needed to print the real time timestamp instead of the monotic one (`CLOCK_MONOTIC` vs `CLOCK_REALTIME`), so I added a switch option (`-T`) to do it. Can you give me feedback about my modest contribution ?

Thanks,
