### PR TITLE
remove build date to fix reproducible builds

### DIFF
--- a/conf_options.c
+++ b/conf_options.c
@@ -526,8 +526,8 @@ void config_parse_file_and_cmdline(int argc, char** argv)
 			conf_filename = optarg;
 			break;
 		case 'v':
-			printf("%s using libuwifi %s (build date: %s %s)\n",
-			       VERSION, UWIFI_VERSION, __DATE__, __TIME__);
+			printf("%s using libuwifi %s\n",
+			       VERSION, UWIFI_VERSION);
 			exit(0);
 		case 'h':
 		case '?':

--- a/display-help.c
+++ b/display-help.c
@@ -38,7 +38,7 @@ void update_help_win(WINDOW *win)
 	print_centered(win, 2, COLS, "HORST - Horsts OLSR Radio Scanning Tool (or)");
 	print_centered(win, 3, COLS, "HORST - Highly Optimized Radio Scanning Tool");
 
-	print_centered(win, 5, COLS, VERSION " using libuwifi %s (build date " __DATE__ " " __TIME__ ")", UWIFI_VERSION);
+	print_centered(win, 5, COLS, VERSION " using libuwifi %s", UWIFI_VERSION);
 	print_centered(win, 6, COLS, "(C) 2005-2016 Bruno Randolf, Licensed under the GPLv2");
 
 	mvwprintw(win, 8, 2, "Known IEEE802.11 Packet Types:");


### PR DESCRIPTION
Build date is one of the common problems to prevent reproducible builds [0].
[0] https://reproducible-builds.org/docs/timestamps/