### PR TITLE
display: always use "%s"-style format for printf()-style functions

### DIFF
--- a/display-main.c
+++ b/display-main.c
@@ -56,7 +56,7 @@ static struct ewma bpsn_avg;
 void print_dump_win(const char *str, int color, bool refresh)
 {
 	wattron(dump_win, color);
-	wprintw(dump_win, str);
+	wprintw(dump_win, "%s", str);
 	wattroff(dump_win, color);
 	if (refresh)
 		wrefresh(dump_win);

--- a/display.c
+++ b/display.c
@@ -88,7 +88,7 @@ print_centered(WINDOW* win, int line, int cols, const char *fmt, ...)
 	vsnprintf(buf, cols, fmt, ap);
 	va_end(ap);
 
-	mvwprintw(win, line, cols / 2 - strlen(buf) / 2, buf);
+	mvwprintw(win, line, cols / 2 - strlen(buf) / 2, "%s", buf);
 	free(buf);
 }
 


### PR DESCRIPTION
    `ncuses-6.3` added printf-style function attributes and now makes
    it easier to catch cases when user input is used in palce of format
    string when built with CFLAGS=-Werror=format-security:

    display-main.c:59:9: error: format not a string literal and no format arguments [-Werror=format-security]
       59 |         wprintw(dump_win, str);
          |         ^~~~~~~

Let's wrap all the missing places with "%s" format.