### PR TITLE
Exit gracefully if conf.intf.ifname does not exist

### DIFF
--- a/main.c
+++ b/main.c
@@ -612,6 +612,10 @@ int main(int argc, char** argv)
 		conf.intf.sock = net_open_client_socket(conf.serveraddr, conf.port);
 		cc_list_head_init(&conf.intf.wlan_nodes);
 	} else {
+		if (!netdev_check_if_exists(conf.intf.ifname)) {
+			fprintf(stderr, "invalid interface name, please check configuration\n");
+			return(-EINVAL);
+		}
 		ifctrl_init();
 		ifctrl_iwget_interface_info(&conf.intf);
 


### PR DESCRIPTION
horst will only work if there is a wlan interface. But if any user tries horst on a system where there is no wifi hardware then it results in a segfault.
As an added benifit this will also protect the user against any misconfiguration of the wlan interface name.

Depends on: https://github.com/br101/libuwifi/pull/9